### PR TITLE
migrating from canopy to single-spa org

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These two steps are often performed during a CI process, to automate deployments
 
 ## Installation and usage
 #### Docker
-import-map-deployer is available on DockerHub as canopytax/import-map-deployer. If you want to run just the single container,
+import-map-deployer is available on DockerHub as single-spa/import-map-deployer. If you want to run just the single container,
 you can run `docker-compose up` from the project root. When running via docker-compose, it will mount a volume in the project root's directory,
 expecting a `config.json` file to be present.
 
@@ -27,7 +27,7 @@ If no configuration file is present, import-map-deployer defaults to using the f
 
 Here are the properties available in the config file:
 - `manifestFormat` (required): A string that is either `"importmap"` or `"sofe"`, which indicates whether the import-map-deployer is
-  interacting with an [import map](https://github.com/WICG/import-maps) or a [sofe manifest](https://github.com/CanopyTax/sofe).
+  interacting with an [import map](https://github.com/WICG/import-maps) or a [sofe manifest](https://github.com/single-spa/sofe).
 - `locations` (required): An object specifying one or more "locations" (or "environments") for which you want the import-map-deployer to control the import map. The special `default`
   location is what will be used when no query parameter `?env=` is provided in calls to the import-map-deployer. If no `default` is provided, the import-map-deployer will create
   a local file called `import-map.json` that will be used as the import map. The keys in the `locations` object are the names of environments, and the values are

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ These two steps are often performed during a CI process, to automate deployments
 
 ## Installation and usage
 #### Docker
-import-map-deployer is available on DockerHub as single-spa/import-map-deployer. If you want to run just the single container,
+import-map-deployer is available on DockerHub as singlespa/import-map-deployer. If you want to run just the single container,
 you can run `docker-compose up` from the project root. When running via docker-compose, it will mount a volume in the project root's directory,
 expecting a `config.json` file to be present.
 
@@ -27,7 +27,7 @@ If no configuration file is present, import-map-deployer defaults to using the f
 
 Here are the properties available in the config file:
 - `manifestFormat` (required): A string that is either `"importmap"` or `"sofe"`, which indicates whether the import-map-deployer is
-  interacting with an [import map](https://github.com/WICG/import-maps) or a [sofe manifest](https://github.com/single-spa/sofe).
+  interacting with an [import map](https://github.com/WICG/import-maps) or a [sofe manifest](https://github.com/CanopyTax/sofe).
 - `locations` (required): An object specifying one or more "locations" (or "environments") for which you want the import-map-deployer to control the import map. The special `default`
   location is what will be used when no query parameter `?env=` is provided in calls to the import-map-deployer. If no `default` is provided, the import-map-deployer will create
   a local file called `import-map.json` that will be used as the import map. The keys in the `locations` object are the names of environments, and the values are

--- a/examples/ci-for-import-map-deployer/gitlab-aws-ecs/Dockerfile
+++ b/examples/ci-for-import-map-deployer/gitlab-aws-ecs/Dockerfile
@@ -1,4 +1,4 @@
-FROM canopytax/import-map-deployer
+FROM single-spa/import-map-deployer
 
 ENV HTTP_USERNAME= HTTP_PASSWORD= AWS_DEFAULT_REGION= STAGING_S3_OBJECT_URL= PRODUCTION_S3_OBJECT_URL=
 

--- a/examples/ci-for-import-map-deployer/gitlab-aws-ecs/Dockerfile
+++ b/examples/ci-for-import-map-deployer/gitlab-aws-ecs/Dockerfile
@@ -1,4 +1,4 @@
-FROM single-spa/import-map-deployer
+FROM singlespa/import-map-deployer
 
 ENV HTTP_USERNAME= HTTP_PASSWORD= AWS_DEFAULT_REGION= STAGING_S3_OBJECT_URL= PRODUCTION_S3_OBJECT_URL=
 

--- a/examples/ci-for-import-map-deployer/k8s-gitlab/Dockerfile
+++ b/examples/ci-for-import-map-deployer/k8s-gitlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM canopytax/import-map-deployer
+FROM single-spa/import-map-deployer
 
 ENV HTTP_USERNAME= HTTP_PASSWORD= DEV_IMPORT_MAP_URL= STAGE_IMPORT_MAP_URL= PROD_IMPORT_MAP_URL=
 

--- a/examples/ci-for-import-map-deployer/k8s-gitlab/Dockerfile
+++ b/examples/ci-for-import-map-deployer/k8s-gitlab/Dockerfile
@@ -1,4 +1,4 @@
-FROM single-spa/import-map-deployer
+FROM singlespa/import-map-deployer
 
 ENV HTTP_USERNAME= HTTP_PASSWORD= DEV_IMPORT_MAP_URL= STAGE_IMPORT_MAP_URL= PROD_IMPORT_MAP_URL=
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CanopyTax/sofe-deplanifester.git"
+    "url": "git+https://github.com/single-spa/sofe-deplanifester.git"
   },
   "keywords": [
     "sofe"
@@ -20,9 +20,9 @@
   "author": "nhumrich",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/CanopyTax/sofe-deplanifester/issues"
+    "url": "https://github.com/single-spa/sofe-deplanifester/issues"
   },
-  "homepage": "https://github.com/CanopyTax/sofe-deplanifester#readme",
+  "homepage": "https://github.com/single-spa/sofe-deplanifester#readme",
   "dependencies": {
     "@google-cloud/storage": "^3.0.3",
     "aws-sdk": "^2.2.27",


### PR DESCRIPTION
This is more than just a documentation change - it moves the published docker image from `CanopyTax/import-map-deployer` to `singlespa/import-map-deployer`. Note that docker hub organizations may not have dashes in them.