### PR TITLE
Disables auth for health check endpoints

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -3,6 +3,7 @@
 const io = require("./io-operations");
 const auth = require("basic-auth");
 
+const publicRoutes = new Set(["/", "/health"]);
 let admins = {};
 
 if (io.username) {
@@ -17,7 +18,7 @@ module.exports = function (req, res, next) {
   var user = auth(req);
   if (
     (!user || !admins[user.name] || admins[user.name].password !== user.pass) &&
-    (req.url != "/" || req.url != "/health")
+    !publicRoutes.has(req.url)
   ) {
     res.set("WWW-Authenticate", 'Basic realm="sofe-deplanifester"');
     return res.status(401).send();


### PR DESCRIPTION
Fixes an issue with / and /health routes being checked for authorisation when basic HTTP auth is enabled.

Implemented a Set for best performance. From the [browser compatibility chart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) I can see that the Set is supported from the initial versions of node, so there should be no problems for modern day usage.

Tested:
* Auth enabled (defined username and password)
    * / and /health endpoints do not need auth header
    * all other endpoints do
    * With valid credentials all routes are available
* Auth disabled
    * No endpoints need auth