### PR TITLE
fix(deleteService): Add delete endpoint get serviceName from body req…

### DIFF
--- a/spec/filesystem.spec.js
+++ b/spec/filesystem.spec.js
@@ -138,4 +138,47 @@ describe("filesystem end to end tests", () => {
         done();
       });
   });
+
+  it("can delete a service from the manifest using serviceName from request body, returning the new manifest", (done) => {
+    const service4 = "fs-service-4";
+    const url4 = "http://localhost:7654/4.js";
+    const service5 = "fs-service-5";
+    const url5 = "http://localhost:7654/5.js";
+
+    api
+      .patchService(service4, url4)
+      .then(() => {
+        api
+          .patchService(service5, url5)
+          .then(() => {
+            api
+              .deleteServiceBodyPayload(service4)
+              .then((delRes) => {
+                expect(delRes.sofe.manifest[service4]).toBe(undefined);
+                api
+                  .getManifest()
+                  .then((getRes) => {
+                    expect(delRes.sofe.manifest[service4]).toBe(undefined);
+                  })
+                  .catch((ex) => {
+                    fail(ex);
+                    done();
+                  });
+                done();
+              })
+              .catch((ex) => {
+                fail(ex);
+                done();
+              });
+          })
+          .catch((ex) => {
+            fail(ex);
+            done();
+          });
+      })
+      .catch((ex) => {
+        fail(ex);
+        done();
+      });
+  });
 });

--- a/spec/http-api.js
+++ b/spec/http-api.js
@@ -51,6 +51,19 @@ exports.deleteService = (serviceName) => {
   });
 };
 
+exports.deleteServiceBodyPayload = (serviceName) => {
+  return new Promise((resolve, reject) => {
+    request("DELETE", `http://localhost:5000/services`)
+      .send({
+        service: serviceName,
+      })
+      .end((err, res) => {
+        if (err || !res.ok) reject(err);
+        else resolve(res.body);
+      });
+  });
+};
+
 exports.getEnvironments = () => {
   return new Promise((resolve, reject) => {
     request("GET", `http://localhost:5000/environments`).end((err, res) => {

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -235,6 +235,20 @@ app.delete("/services/:serviceName", function (req, res) {
     });
 });
 
+app.delete("/services", function (req, res) {
+  let env = getEnv(req);
+  const { serviceName } = req.body;
+  modify
+    .modifyService(env, serviceName, null, true)
+    .then((data) => {
+      res.send(data);
+    })
+    .catch((ex) => {
+      console.error(ex);
+      res.status(500).send(`Could not delete service ${serviceName}`);
+    });
+});
+
 var server = app.listen(config.port || 5000, function () {
   console.log("Listening at http://localhost:%s", server.address().port);
 });


### PR DESCRIPTION
This PR allows another way to delete import-map.json old references:
- Expose a delete endpoint to **/services** path and gets the **serviceName** from body request

Fix this issue: https://github.com/single-spa/import-map-deployer/issues/62