### PR TITLE
docs: adds example for travis ci, aws, and no import map deployer

### DIFF
--- a/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/.travis.yml
+++ b/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/.travis.yml
@@ -1,0 +1,33 @@
+# See https://github.com/thawkin3/single-spa-demo-root-config/blob/master/.travis.yml
+
+language: node_js
+node_js:
+  - node
+env:
+  global:
+    # include $HOME/.local/bin for `aws`
+    - PATH=$HOME/.local/bin:$PATH
+before_install:
+  - pyenv global 3.7.1
+  - pip install -U pip
+  - pip install awscli
+script:
+  - yarn build
+  - echo "Commit sha - $TRAVIS_COMMIT"
+  - mkdir -p dist/$ORG_NAME/$PROJECT_NAME/$TRAVIS_COMMIT
+  - mv dist/*.* dist/$ORG_NAME/$PROJECT_NAME/$TRAVIS_COMMIT/
+deploy:
+  provider: s3
+  access_key_id: "$AWS_ACCESS_KEY_ID"
+  secret_access_key: "$AWS_SECRET_ACCESS_KEY"
+  bucket: "$BUCKET_NAME"
+  region: "$REGION_NAME"
+  cache-control: "max-age=31536000"
+  acl: "public_read"
+  local_dir: dist
+  skip_cleanup: true
+  on:
+    branch: master
+after_deploy:
+  - chmod +x after_deploy.sh
+  - "./after_deploy.sh"

--- a/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/after_deploy.sh
+++ b/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/after_deploy.sh
@@ -1,0 +1,9 @@
+# See https://github.com/thawkin3/single-spa-demo-root-config/blob/master/after_deploy.sh
+
+echo "Downloading import map from S3"
+aws s3 cp s3://$BUCKET_NAME/$ORG_NAME/importmap.json importmap.json
+echo "Updating import map to point to new version of $ORG_NAME/$PROJECT_NAME"
+node update-importmap.mjs
+echo "Uploading new import map to S3"
+aws s3 cp importmap.json s3://$BUCKET_NAME/$ORG_NAME/importmap.json --cache-control 'public, must-revalidate, max-age=0' --acl 'public-read'
+echo "Deployment successful"

--- a/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/update-importmap.mjs
+++ b/examples/ci-for-javascript-repo/travis-aws-no-import-map-deployer/update-importmap.mjs
@@ -1,0 +1,49 @@
+// See https://github.com/thawkin3/single-spa-demo-root-config/blob/master/update-importmap.mjs
+//   and in this repo: examples/ci-for-javascript-repo/gitlab-aws-no-import-map-deployer/update-importmap.mjs
+
+// Note that this file requires node@13.2.0 or higher (or the --experimental-modules flag)
+import fs from "fs";
+import path from "path";
+import https from "https";
+
+const importMapFilePath = path.resolve(process.cwd(), "importmap.json");
+const importMap = JSON.parse(fs.readFileSync(importMapFilePath));
+const url = `${process.env.PUBLIC_CDN_URL}/${process.env.ORG_NAME}/${process.env.PROJECT_NAME}/${process.env.TRAVIS_COMMIT}/${process.env.PROJECT_NAME}.js`;
+
+https
+  .get(url, (res) => {
+    // HTTP redirects (301, 302, etc) not currently supported, but could be added
+    if (res.statusCode >= 200 && res.statusCode < 300) {
+      if (
+        res.headers["content-type"] &&
+        res.headers["content-type"].toLowerCase().trim() ===
+          "application/javascript"
+      ) {
+        const moduleName = `${process.env.ORG_NAME}/${process.env.PROJECT_NAME}`;
+        importMap.imports[moduleName] = url;
+        fs.writeFileSync(importMapFilePath, JSON.stringify(importMap, null, 2));
+        console.log(
+          `Updated import map for module ${moduleName}. New url is ${url}.`
+        );
+      } else {
+        urlNotDownloadable(
+          url,
+          Error(`Content-Type response header must be application/javascript`)
+        );
+      }
+    } else {
+      urlNotDownloadable(
+        url,
+        Error(`HTTP response status was ${res.statusCode}`)
+      );
+    }
+  })
+  .on("error", (err) => {
+    urlNotDownloadable(url, err);
+  });
+
+function urlNotDownloadable(url, err) {
+  throw Error(
+    `Refusing to update import map - could not download javascript file at url ${url}. Error was '${err.message}'`
+  );
+}


### PR DESCRIPTION
I've added an example of a single-spa setup that uses Travis CI, AWS S3, and no import map deployer. There wasn't one for that particular combination of services, so I thought this would be helpful.

This is part of the setup that you can see in my repo here: https://github.com/thawkin3/single-spa-demo-root-config

I also wrote an article about my whole single-spa app setup that walks through this process of updating the import map too: https://medium.com/swlh/developing-and-deploying-micro-frontends-with-single-spa-c8b49f2a1b1d?source=friends_link&sk=8f72c248806e0d023ec8f2c872ef2983