### PR TITLE
fix: corrects the github urls in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/single-spa/sofe-deplanifester.git"
+    "url": "git+https://github.com/single-spa/import-map-deployer.git"
   },
   "keywords": [
     "sofe"
@@ -27,14 +27,14 @@
     "node": ">=10.0.0"
   },
   "bugs": {
-    "url": "https://github.com/single-spa/sofe-deplanifester/issues"
+    "url": "https://github.com/single-spa/import-map-deployer/issues"
   },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged && yarn lint && yarn test"
     }
   },
-  "homepage": "https://github.com/single-spa/sofe-deplanifester#readme",
+  "homepage": "https://github.com/single-spa/import-map-deployer#readme",
   "dependencies": {
     "@azure/storage-blob": "^12.1.2",
     "@google-cloud/storage": "^3.0.3",


### PR DESCRIPTION
It looks like the GitHub urls in the `package.json` file are incorrect. It links to https://github.com/single-spa/sofe-deplanifester, but this project is found at https://github.com/single-spa/import-map-deployer.

When I try to follow the original link, I get a 404 page, which either means the old repo doesn't exist or I just don't have permission to see it (sneaky GitHub disguising 403s as 404s).

Anyway, feel free to close this PR if I'm mistaken, but it seems like we should update these.