### PR TITLE
[Feature] Set auth credentials from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ module.exports = {
 }
 ```
 
+### Setting Authentication Credentials
+
+Basic auth credentials can be set either in the `config.json` file (see above) or using the following environment variables:
+
+- `IMD_USERNAME`
+- `IMD_PASSWORD`
+
+> :information_source: **Both** environment variables must be set for them to take effect.
+
+> :warning: The above environment variables will **override** the username and password from the config file.
+
 ## Built-in IO Methods
 
 The import-map-deployer knows how to update import maps that are stored in the following ways:

--- a/src/io-operations.js
+++ b/src/io-operations.js
@@ -57,12 +57,6 @@ function useDefaultIOMethod() {
   writeManifest = defaultIOMethod.writeManifest;
 }
 
-function getCredentialsFromEnv() {
-  const envUsername = process.env.IMD_USERNAME;
-  const envPassword = process.env.IMD_PASSWORD;
-  return { username: envUsername, password: envPassword };
-}
-
 exports.readManifest = (env) => {
   return new Promise((resolve, reject) => {
     readManifest(env)
@@ -79,13 +73,9 @@ exports.readManifest = (env) => {
 };
 
 // Override username and password if both env vars are set
-const {
-  username: envUsername,
-  password: envPassword,
-} = getCredentialsFromEnv();
-if (envUsername && envPassword) {
-  username = envUsername;
-  password = envPassword;
+if (process.env.IMD_USERNAME && process.env.IMD_PASSWORD) {
+  username = process.env.IMD_USERNAME;
+  password = process.env.IMD_PASSWORD;
 }
 
 exports.writeManifest = writeManifest;

--- a/src/io-operations.js
+++ b/src/io-operations.js
@@ -57,6 +57,12 @@ function useDefaultIOMethod() {
   writeManifest = defaultIOMethod.writeManifest;
 }
 
+function getCredentialsFromEnv() {
+  const envUsername = process.env.IMD_USERNAME;
+  const envPassword = process.env.IMD_PASSWORD;
+  return { username: envUsername, password: envPassword };
+}
+
 exports.readManifest = (env) => {
   return new Promise((resolve, reject) => {
     readManifest(env)
@@ -71,6 +77,16 @@ exports.readManifest = (env) => {
       });
   });
 };
+
+// Override username and password if both env vars are set
+const {
+  username: envUsername,
+  password: envPassword,
+} = getCredentialsFromEnv();
+if (envUsername && envPassword) {
+  username = envUsername;
+  password = envPassword;
+}
 
 exports.writeManifest = writeManifest;
 exports.username = username;


### PR DESCRIPTION
This feature adds support for setting the authentication credentials via environment variables.

- `IMD_USERNAME`: the username to use for basic auth
- `IMD_PASSWORD`: the password to use for basic auth

*Both* variables must be set for them to take effect. If both are set, they will override any auth credentials defined in the configuration file.