### PR TITLE
Throw error if invalid manifestFormat provided

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,4 @@ yarn.lock
 LICENSE
 Dockerfile
 spec/mockServices
+*.sh

--- a/README.md
+++ b/README.md
@@ -151,20 +151,20 @@ module.exports = {
   // The type of json file that should be updated. Import-maps are two ways of defining URLs for javascript module.
   manifestFormat: "importmap|sofe",
   // Optional, if you are using a built-in "IO Method"
-  readManifest: function(env) {
+  readManifest: function (env) {
     return new Promise((resolve, reject) => {
-      const manifest = ''; //read a string from somewhere
+      const manifest = ""; //read a string from somewhere
       resolve(manifest); //must resolve a string
     });
   },
   // Optional, if you are using a built-in "IO Method"
-  writeManifest: function() {
+  writeManifest: function () {
     return new Promise((resolve, reject) => {
       //write the file....
       resolve(); //you don't have to call resolve with any value
     });
-  }
-}
+  },
+};
 ```
 
 ### Setting Authentication Credentials

--- a/src/modify.js
+++ b/src/modify.js
@@ -11,9 +11,11 @@ const isImportMap = () => {
   } else if (format === "sofe") {
     return false;
   } else {
-    throw new Error(`Invalid manifestFormat '${format}'. Must be 'importmap' or 'sofe'.`);
-  };
-}
+    throw new Error(
+      `Invalid manifestFormat '${format}'. Must be 'importmap' or 'sofe'.`
+    );
+  }
+};
 
 function getMapFromManifest(manifest) {
   return isImportMap() ? manifest.imports : manifest.sofe.manifest;

--- a/src/modify.js
+++ b/src/modify.js
@@ -4,7 +4,16 @@ const lock = new (require("rwlock"))();
 const ioOperations = require("./io-operations.js");
 const getConfig = require("./config").getConfig;
 
-const isImportMap = () => getConfig().manifestFormat === "importmap";
+const isImportMap = () => {
+  const format = getConfig().manifestFormat;
+  if (format === "importmap") {
+    return true;
+  } else if (format === "sofe") {
+    return false;
+  } else {
+    throw new Error(`Invalid manifestFormat '${format}'. Must be 'importmap' or 'sofe'.`);
+  };
+}
 
 function getMapFromManifest(manifest) {
   return isImportMap() ? manifest.imports : manifest.sofe.manifest;


### PR DESCRIPTION
Current behavior is to log
```
TypeError: Cannot read property 'manifest' of undefined          
    at getMapFromManifest (/www/src/modify.js:10:59)
    at modifyLock (/www/src/modify.js:103:17)                    
    at ioOperations.readManifest.then (/www/src/modify.js:53:18) 
    at process._tickCallback (internal/process/next_tick.js:68:7)
```
when the endpoint is hit.

This change causes the server to fail to start if the `manifestFormat` is invalid, with a message like
```
Listening at http://localhost:5000
Error: Invalid manifestFormat 'import-map'. Must be 'importmap' or 'sofe'.
    at isImportMap (/www/src/modify.js:14:10)
    at getEmptyManifest (/www/src/modify.js:32:10)
    at readManifest.then (/www/src/io-operations.js:65:37)
Killing web server because initial health check failed
```