### PR TITLE
Fix/docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.github/
+node_modules/
+examples/
+.dockerignore
+.gitignore
+.travis.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-FROM mhart/alpine-node:10 as build
+FROM node:10-alpine as build
 WORKDIR /www
 COPY package.json yarn.lock ./
 RUN yarn install
 COPY . /www/
 
-FROM mhart/alpine-node:10 as release
+FROM node:10-alpine as release
+USER node
 ARG container_port=5000
 ENV PORT=$container_port
 EXPOSE $PORT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:10-alpine as build
+FROM node:14-alpine as build
 WORKDIR /www
 COPY package.json yarn.lock ./
 RUN yarn install  --production --frozen-lockfile
 COPY . /www/
 
-FROM node:10-alpine as release
+FROM node:14-alpine as release
 USER node
 ARG container_port=5000
 ENV PORT=$container_port

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,13 @@
-FROM mhart/alpine-node:10
-COPY . /www/
+FROM mhart/alpine-node:10 as build
 WORKDIR /www
+COPY package.json yarn.lock ./
+RUN yarn install
+COPY . /www/
+
+FROM mhart/alpine-node:10 as release
 ARG container_port=5000
 ENV PORT=$container_port
 EXPOSE $PORT
-RUN yarn install
+WORKDIR /www
+COPY --from=build --chown=root:root /www /www
 CMD yarn start

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ ENV NODE_ENV=production
 EXPOSE $PORT
 WORKDIR /www
 COPY --from=build --chown=root:root /www /www
-CMD yarn start
+CMD ["node", "src/web-server.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM node:10-alpine as build
 WORKDIR /www
 COPY package.json yarn.lock ./
-RUN yarn install
+RUN yarn install  --production --frozen-lockfile
 COPY . /www/
 
 FROM node:10-alpine as release
 USER node
 ARG container_port=5000
 ENV PORT=$container_port
+ENV NODE_ENV=production
 EXPOSE $PORT
 WORKDIR /www
 COPY --from=build --chown=root:root /www /www

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "author": "nhumrich",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "bugs": {
     "url": "https://github.com/single-spa/import-map-deployer/issues"


### PR DESCRIPTION
We're just looking to start using single-spa and wanted to suggest a few changes to the Docker image.  Hopefully they're agreeable but, if not, we're totally happy to keep these on a private fork just for our use.

1. For production use, we prefer to run containers as a non-root user.  I've switched over to the official Node.js base image since I don't think this was ever fully fixed in mhart's image (see discussion in https://github.com/mhart/alpine-node/issues/48)
1. As [recommended on the Docker Blog](https://www.docker.com/blog/keep-nodejs-rockin-in-docker/), switch to calling the Node binary directly rather than via Yarn
1. Also added a `.dockerignore` to exclude a few surplus files

Overall these changes have also reduced image size from 337 MB down to 146 MB.