### PR TITLE
Add "tini" to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ RUN yarn install  --production --frozen-lockfile
 COPY . /www/
 
 FROM node:14-alpine as release
+RUN apk --no-cache add tini
+ENTRYPOINT ["tini", "--"]
 USER node
 ARG container_port=5000
 ENV PORT=$container_port


### PR DESCRIPTION
Tini is a tiny init process for docker containers that ensure that they handle SIGTERM/SIGKILL etc. in all environments correctly. You can read more here: https://github.com/krallin/tini

This is added as an `ENTRYPOINT`, so that it will automatically be used for any container built on top of this one which overrides `CMD`. Since TINI is an init process, adding it as an entrypoint should be completely backwards compatible with any already working container build on top of this one.