### PR TITLE
Fixes AWS cache control order issue

### DIFF
--- a/src/cache-control.js
+++ b/src/cache-control.js
@@ -5,4 +5,4 @@ exports.getCacheControl = (hostSpecificCacheControl) => {
     return config.cacheControl;
   }
   return hostSpecificCacheControl || "public, must-revalidate, max-age=0";
-}
+};

--- a/src/cache-control.js
+++ b/src/cache-control.js
@@ -1,4 +1,8 @@
 const { config } = require("./config");
 
-exports.cacheControl =
-  config.cacheControl || "public, must-revalidate, max-age=0";
+exports.getCacheControl = (hostSpecificCacheControl) => {
+  if (config.cacheControl) {
+    return config.cacheControl;
+  }
+  return hostSpecificCacheControl || "public, must-revalidate, max-age=0";
+}

--- a/src/io-methods/azure.js
+++ b/src/io-methods/azure.js
@@ -3,7 +3,7 @@ const {
   StorageSharedKeyCredential,
 } = require("@azure/storage-blob");
 
-const { cacheControl } = require("../cache-control");
+const { getCacheControl } = require("../cache-control");
 
 async function createBlobService(target) {
   const connectionString =
@@ -61,7 +61,7 @@ exports.writeManifest = async function (target, content) {
   const blockBlobClient = containerClient.getBlockBlobClient(target.azureBlob);
   return await blockBlobClient.upload(content, content.length, {
     blobHTTPHeaders: {
-      blobCacheControl: cacheControl,
+      blobCacheControl: getCacheControl(),
       blobContentType: "application/importmap+json",
     },
   });

--- a/src/io-methods/google-cloud-storage.js
+++ b/src/io-methods/google-cloud-storage.js
@@ -4,7 +4,7 @@ const storage = new Storage();
 
 const regex = /^google:\/\/(.+)\/(.+)$/;
 
-const { cacheControl } = require("../cache-control");
+const { getCacheControl } = require("../cache-control");
 
 function parseFilePath(filePath) {
   const [_, bucketName, fileName] = regex.exec(filePath);
@@ -32,7 +32,7 @@ exports.writeManifest = function (filePath, data) {
     return storage.bucket(bucketName).file(fileName).save(data, {
       contentType: "application/importmap+json",
       metadata: {
-        cacheControl,
+        cacheControl: getCacheControl(),
       },
     });
   });

--- a/src/io-methods/google-cloud-storage.js
+++ b/src/io-methods/google-cloud-storage.js
@@ -29,11 +29,14 @@ exports.writeManifest = function (filePath, data) {
   return Promise.resolve().then(() => {
     const { bucketName, fileName } = parseFilePath(filePath);
 
-    return storage.bucket(bucketName).file(fileName).save(data, {
-      contentType: "application/importmap+json",
-      metadata: {
-        cacheControl: getCacheControl(),
-      },
-    });
+    return storage
+      .bucket(bucketName)
+      .file(fileName)
+      .save(data, {
+        contentType: "application/importmap+json",
+        metadata: {
+          cacheControl: getCacheControl(),
+        },
+      });
   });
 };

--- a/src/io-methods/s3.js
+++ b/src/io-methods/s3.js
@@ -59,9 +59,9 @@ exports.writeManifest = function (filePath, data) {
         Key: file.key,
         Body: data,
         ContentType: "application/importmap+json",
-        CacheControl: cacheControl,
         ACL: "public-read",
         ...s3PutObjectConfig,
+        CacheControl: cacheControl,
       },
       function (err) {
         if (err) reject(err);
@@ -83,9 +83,9 @@ exports.writeManifest = function (filePath, data) {
           Key: jsKey,
           Body: jsHelpers.createJsString(data),
           ContentType: "application/importmap+json",
-          CacheControl: cacheControl,
           ACL: "public-read",
           ...s3PutObjectConfig,
+          CacheControl: cacheControl,
         },
         function (err) {
           if (err) reject(err);


### PR DESCRIPTION
This solves the problem where someone could set cacheControl in the config but it would be overridden by s3.putObject.CacheControl if that were also set. 