### PR TITLE
Fix issue with gcp bucket/key regex. Resolves #99.

### DIFF
--- a/src/io-methods/google-cloud-storage.js
+++ b/src/io-methods/google-cloud-storage.js
@@ -2,7 +2,7 @@ const { Storage } = require("@google-cloud/storage");
 
 const storage = new Storage();
 
-const regex = /^(?:google|gs):\/\/(.+)\/(.+)$/;
+const regex = /^(?:google|gs):\/\/(.+?)\/(.+)$/;
 
 const { getCacheControl } = require("../cache-control");
 


### PR DESCRIPTION
See #99.

```js
// Old code that's incorrect
var [_, bucket, key] = /^(?:google|gs):\/\/(.+)\/(.+)$/.exec('gs://bucketname/prod/importmap.json')
console.log("bucket", bucket, "key", key) // "bucket" "bucketname/prod" "key" "importmap.json"

// New code that's correct
var [_, bucket, key] = /^(?:google|gs):\/\/(.+?)\/(.+)$/.exec('gs://bucketname/prod/importmap.json')
console.log("bucket", bucket, "key", key) // "bucket" "bucketname" "key" "prod/importmap.json"
```