### PR TITLE
Create import map if not present in azure storage

### DIFF
--- a/src/io-methods/azure.js
+++ b/src/io-methods/azure.js
@@ -4,6 +4,7 @@ const {
 } = require("@azure/storage-blob");
 
 const { getCacheControl } = require("../cache-control");
+const { getEmptyManifest } = require("../modify");
 
 async function createBlobService(target) {
   const connectionString =
@@ -47,6 +48,11 @@ exports.readManifest = async function (target) {
   const blobService = await createBlobService(target);
   const containerClient = blobService.getContainerClient(target.azureContainer);
   const blobClient = containerClient.getBlobClient(target.azureBlob);
+  const blobExists = await blobClient.exists(target.azureBlob);
+
+  if (!blobExists) {
+    await exports.writeManifest(target, JSON.stringify(getEmptyManifest()));
+  }
 
   const downloadBlockBlobResponse = await blobClient.download();
   const response = await streamToString(


### PR DESCRIPTION
Resolves #98 for one more I/O method

Tests:
1. Started with no file in Azure blob storage
2. Started the server
3. The file was auto-created

1. Had a import-map file in azure blob storage
2. Started the server
3. The file was not reset