### PR TITLE
checking if file exist and if it does not create it

### DIFF
--- a/src/io-methods/filesystem.js
+++ b/src/io-methods/filesystem.js
@@ -1,10 +1,19 @@
 "use strict";
 const fs = require("fs/promises");
 const { getConfig } = require("../config");
+const { getEmptyManifest } = require("../modify");
 const jsHelpers = require("./js-file-helpers.js");
 
-exports.readManifest = function (filePath) {
-  return fs.readFile(filePath, "utf-8");
+exports.readManifest = async function (filePath) {
+  try {
+    await fs.access(filePath, fs.F_OK);
+
+    return fs.readFile(filePath, "utf-8");
+  } catch (missingFileErr) {
+    exports.writeManifest(filePath, JSON.stringify(getEmptyManifest()));
+
+    return fs.readFile(filePath, "utf-8");
+  }
 };
 
 exports.writeManifest = function (filePath, data) {

--- a/src/io-methods/filesystem.js
+++ b/src/io-methods/filesystem.js
@@ -10,7 +10,7 @@ exports.readManifest = async function (filePath) {
 
     return fs.readFile(filePath, "utf-8");
   } catch (missingFileErr) {
-    exports.writeManifest(filePath, JSON.stringify(getEmptyManifest()));
+    await exports.writeManifest(filePath, JSON.stringify(getEmptyManifest()));
 
     return fs.readFile(filePath, "utf-8");
   }


### PR DESCRIPTION
Part of #98 

Initially, the server breaks if there is no import map on the local filesystem.

After the changes, the server is creating the import map when it is missing and, when restarted, the file does not get reset.