### PR TITLE
Preventing "" as a service key

### DIFF
--- a/src/verify-valid-input-format.js
+++ b/src/verify-valid-input-format.js
@@ -32,7 +32,7 @@ exports.verifyInputFormatForServices = function (services) {
       errorsToReport.push(
         `Invalid import map in request body -- module with name '${moduleName}' does not have a string url`
       );
-    } else if (!moduleName) {
+    } else if (!moduleName || moduleName.trim().length === 0) {
       // catch times where the name evaluates to false, such as "".
       errorsToReport.push(
         `Invalid module name -- module name '${moduleName}' is invalid`

--- a/src/verify-valid-input-format.js
+++ b/src/verify-valid-input-format.js
@@ -32,6 +32,11 @@ exports.verifyInputFormatForServices = function (services) {
       errorsToReport.push(
         `Invalid import map in request body -- module with name '${moduleName}' does not have a string url`
       );
+    } else if (!moduleName) {
+      // catch times where the name evaluates to false, such as "".
+      errorsToReport.push(
+        `Invalid module name -- module name '${moduleName}' is invalid`
+      );
     } else {
       if (moduleName.endsWith("/") && !services[moduleName].endsWith("/")) {
         errorsToReport.push(

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -234,7 +234,7 @@ app.patch("/services", function (req, res) {
   } else {
     return res.status(400).send("service key is missing");
   }
-  if (!service) {
+  if (!service || service.trim().length === 0) {
     return res
       .status(400)
       .send(`Invalid service key - "${service}" is an invalid service key`);

--- a/src/web-server.js
+++ b/src/web-server.js
@@ -234,6 +234,11 @@ app.patch("/services", function (req, res) {
   } else {
     return res.status(400).send("service key is missing");
   }
+  if (!service) {
+    return res
+      .status(400)
+      .send(`Invalid service key - "${service}" is an invalid service key`);
+  }
   if (req.body != undefined && req.body.hasOwnProperty("url")) {
     url = req.body.url;
   } else {

--- a/test/import-map.test.js
+++ b/test/import-map.test.js
@@ -238,4 +238,33 @@ describe(`/import-map.json`, () => {
       .set("accept", "json")
       .expect(404);
   });
+
+  it(`returns a 400 when you attempt to patch the import map with an invalid name`, async () => {
+    await request(app)
+      .patch("/import-map.json")
+      .query({
+        skip_url_check: true,
+      })
+      .set("accept", "json")
+      .send({
+        imports: {
+          "": "/something.js",
+        },
+      })
+      .expect(400);
+  });
+
+  it(`returns a 400 when you attempt to patch a service with an invalid name`, async () => {
+    await request(app)
+      .patch("/services")
+      .query({
+        skip_url_check: true,
+      })
+      .set("accept", "json")
+      .send({
+        service: "",
+        url: "/a-1-updated.mjs",
+      })
+      .expect(400);
+  });
 });


### PR DESCRIPTION
Due to an internal configuration error I discovered that `import-map-deployer` accepts "" as a valid key in PATCH requests at  `/services` & `/import-map`. 

After fixing the internal configuration error I thought it might be wise to prevent this behavior. I believe it's technically valid for an import-map to have a key of "", but I figured it still might be worth preventing.