### PR TITLE
fix: alphabetical sort method now handles missing data better

### DIFF
--- a/src/modify.js
+++ b/src/modify.js
@@ -86,14 +86,12 @@ exports.modifyImportMap = function (env, newValues) {
   const { services, scopes } = newValues;
 
   const alphabetical = !!getConfig().alphabetical;
-  const newImports =
-    services && typeof services === "object" && alphabetical
-      ? sortObjectAlphabeticallyByKeys(services)
-      : services;
-  const newScopes =
-    scopes && typeof scopes === "object" && alphabetical
-      ? sortObjectAlphabeticallyByKeys(scopes)
-      : scopes;
+  const newImports = alphabetical
+    ? sortObjectAlphabeticallyByKeys(services)
+    : services;
+  const newScopes = alphabetical
+    ? sortObjectAlphabeticallyByKeys(scopes)
+    : scopes;
 
   // either imports or scopes have to be defined
   if (newImports || newScopes) {
@@ -160,6 +158,9 @@ exports.modifyService = function (
 exports.getEmptyManifest = getEmptyManifest;
 
 function sortObjectAlphabeticallyByKeys(unordered) {
+  if (!unordered) {
+    return unordered;
+  }
   return Object.keys(unordered)
     .sort()
     .reduce((obj, key) => {
@@ -167,3 +168,5 @@ function sortObjectAlphabeticallyByKeys(unordered) {
       return obj;
     }, {});
 }
+
+exports.sortObjectAlphabeticallyByKeys = sortObjectAlphabeticallyByKeys;

--- a/test/alphabetical-import-map.test.js
+++ b/test/alphabetical-import-map.test.js
@@ -3,6 +3,7 @@ const { app, setConfig } = require("../src/web-server");
 const {
   resetManifest: resetMemoryManifest,
 } = require("../src/io-methods/memory");
+const { sortObjectAlphabeticallyByKeys } = require("../src/modify.js");
 
 describe(`alphabetically sorted`, () => {
   beforeAll(() => {
@@ -57,6 +58,12 @@ describe(`alphabetically sorted`, () => {
     expect(JSON.stringify(response.body.imports)).toBe(
       `{"a":"/a-1-updated.mjs","b":"/b-1.mjs","c":"/c-1.mjs"}`
     );
+  });
+
+  it("should return undefined or null if you pass them in and not throw an error", () => {
+    expect(sortObjectAlphabeticallyByKeys(undefined)).toBe(undefined);
+    expect(sortObjectAlphabeticallyByKeys(null)).toBe(null);
+    expect(JSON.stringify(sortObjectAlphabeticallyByKeys({}))).toBe("{}");
   });
 });
 


### PR DESCRIPTION
We had a small error where one of our import-maps didn't have a "scope" property and using `alphabetical: true` threw errors. Correcting the data was enough to fix it but I thought I would be nice to also handle this better and clean up the code a bit.