### PR TITLE
Adding note to README about GCP/Azure concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ If you are not comfortable with running the import-map-deployer at all, you do n
 
 If you do this, decide whether you care about the deployment race condition scenario described in the [Why does this exist?](#why-does-this-exist) section. If you are willing to live with that unlikely race condition, see these examples ([1](/examples/ci-for-javascript-repo/gitlab-aws-no-import-map-deployer), [2](/examples/bash-aws-no-import-map-deployer)) for some example CI commands.
 
+Note that several object stores (notably Google Cloud Storage and Azure Storage) allow for optimistic concurrency when uploading files. By correctly sending pre-condition headers on those services, your CI process can correctly fail and/or retry in the event of a race condition. For further reading, see [Azure's docs](https://docs.microsoft.com/en-us/azure/storage/blobs/concurrency-manage?tabs=dotnet#optimistic-concurrency) or [Google Cloud's docs](https://cloud.google.com/storage/docs/request-preconditions) on concurrency.
+
 If you do want to address the deployment race condition without using import-map-deployer, we'd love to hear what you come up with. Consider leaving a PR to these docs that explain what you did!
 
 ## Example repository


### PR DESCRIPTION
In reaction to: 

> If you do want to address the deployment race condition without using import-map-deployer, we'd love to hear what you come up with. Consider leaving a PR to these docs that explain what you did!

S3 _does not_ allow for this strategy, but it's valid on several other storage providers as mentioned.

* [Azure's docs](https://docs.microsoft.com/en-us/azure/storage/blobs/concurrency-manage?tabs=dotnet#optimistic-concurrency)
* [Google Cloud's docs](https://cloud.google.com/storage/docs/request-preconditions)

## example

To verify the process, I've implemented a basic GCP flow in a rough shell script:

```sh
#!/bin/bash
set -euxo pipefail

Bucket="${1}"
Specifier="${2}"
Destination="${3}"
JsonFile="${Bucket}/bundles/latest.json"

# Check that the target is really there
gsutil cat "${Bucket}${Destination}" | wc -c

# Operate optimistically on a single generation
# (If we race someone else with the file, only one will succeed)
CurrentVersion=$(gsutil ls -a "${JsonFile}" | cut -d'#' -f2)
gsutil cat "${JsonFile}#${CurrentVersion}" \
| jq \
    --arg specifier "$Specifier" \
    --arg target "$Destination" \
    '.imports[$specifier] = $target' \
| gsutil \
    -h "x-goog-if-generation-match: ${CurrentVersion}" \
    -h "cache-control: max-age=60" \
    cp - "${JsonFile}"
```

It didn't seem fit to include in the README itself, given the scope of the doc/repo.