### PR TITLE
Default manifestFile to "importmap"

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Here are the properties available in the config file:
 
 - `urlSafeList` (optional, but **highly** recommended): An array of strings and/or functions that indicate which URLs are trusted when updating the import map. A string value is treated as a URL prefix - for example `https://unpkg.com/`. A function value is called with a [URL object](https://developer.mozilla.org/en-US/docs/Web/API/URL) and must return a truthy value when the URL is trusted. Any attempt to update the import map to include an untrusted URL will be rejected. If you omit `urlSafeList`, all URLs are considered trusted (not recommended).
 - `packagesViaTrailingSlashes` (optional, defaults to true): A boolean that indicates whether to turn off the automatic generation of trailing slash package records on PATCH service requests. For more information and examples visit [standard guideline](https://github.com/WICG/import-maps/#packages-via-trailing-slashes).
-- `manifestFormat` (required): A string that is either `"importmap"` or `"sofe"`, which indicates whether the import-map-deployer is
+- `manifestFormat` (optional, defaults to `"importmap"`): A string that is either `"importmap"` or `"sofe"`. Sofe is for legacy use.
   interacting with an [import map](https://github.com/WICG/import-maps) or a [sofe manifest](https://github.com/CanopyTax/sofe).
 - `locations` (required): An object specifying one or more "locations" (or "environments") for which you want the import-map-deployer to control the import map. The special `default`
   location is what will be used when no query parameter `?env=` is provided in calls to the import-map-deployer. If no `default` is provided, the import-map-deployer will create

--- a/src/config.js
+++ b/src/config.js
@@ -3,9 +3,13 @@ const fs = require("fs"),
   path = require("path"),
   argv = require("minimist")(process.argv.slice(2));
 
+const defaultConfig = {
+  manifestFormat: "importmap",
+};
+
 if (argv._.length > 1)
   throw new Error(
-    `sofe-deplanifester expects only a single argument, which is the configuration file`
+    `import-map-deployer expects only a single argument, which is the configuration file`
   );
 
 let config = {};
@@ -20,5 +24,14 @@ if (argv._.length === 0) {
   }
 }
 
-exports.setConfig = (newConfig) => (config = newConfig);
+config = applyDefaults(config);
+
+exports.setConfig = (newConfig) => (config = applyDefaults(newConfig));
 exports.getConfig = () => config;
+
+function applyDefaults(config) {
+  return {
+    ...defaultConfig,
+    ...config,
+  };
+}


### PR DESCRIPTION
I don't think any organization is still using sofe, so importmap makes sense as default